### PR TITLE
Don't hardcode PATH

### DIFF
--- a/modules/kolide-launcher/default.nix
+++ b/modules/kolide-launcher/default.nix
@@ -56,8 +56,10 @@ in
 
       # Hard requirements should go in list; optional requirements should be added as optional.
       # Intentionally not included because they aren't supported on Nix:
-      # CrowdStrike (falconctl, falcon-kernel-check), Carbon Black (repcli), dnf (dnf5 is available),
-      # x-www-browser (symlink created via `update-alternatives`, which isn't available)
+      # - CrowdStrike (falconctl, falcon-kernel-check)
+      # - Carbon Black (repcli)
+      # - dnf (related libraries dnf5, libdnf, and microdnf are available, but nothing provides the dnf binary)
+      # - x-www-browser (symlink created via `update-alternatives`, which isn't available)
       path = with pkgs; [
         patchelf # Required to auto-update successfully
         systemd # Provides loginctl, systemctl; loginctl required to run desktop


### PR DESCRIPTION
We don't want to rely on the static paths like `/run/current-system/sw/bin` because its contents will change if the user reinstalls anything. Instead, set the systemd service path to include all dependencies from [allowedcmd](https://github.com/kolide/launcher/blob/main/ee/allowedcmd/cmd_linux.go). If we don't require the dependency, mark it as optional depending on install status, so that we don't e.g. install zerotier when it's not already there and in use.