### PR TITLE
Use root directory that is consistent with other launcher installations

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ adjust other config values as needed:
   services.kolide-launcher = {
     enable = true;
     kolideHostname = "k2device-preprod.kolide.com";
-    rootDirectory = "/var/lib/kolide-k2/k2device-preprod.kolide.com";
+    rootDirectory = "/var/kolide-k2/k2device-preprod.kolide.com";
     updateChannel = "nightly";
   };
 }

--- a/modules/kolide-launcher/default.nix
+++ b/modules/kolide-launcher/default.nix
@@ -23,7 +23,7 @@ in
 
     rootDirectory = mkOption {
       type = types.path;
-      default = "/var/lib/kolide-k2/k2device.kolide.com";
+      default = "/var/kolide-k2/k2device.kolide.com";
       description = ''
         The path to the directory that will hold launcher-related data,
         including logs, databases, and autoupdates.

--- a/tests/kolide-launcher.nix
+++ b/tests/kolide-launcher.nix
@@ -57,7 +57,7 @@ pkgs.nixosTest {
         machine.systemctl("stop kolide-launcher.service")
 
       with subtest("launcher set up correctly"):
-        machine.wait_for_file("/var/lib/kolide-k2/k2device.kolide.com/debug.json")
+        machine.wait_for_file("/var/kolide-k2/k2device.kolide.com/debug.json")
 
       with subtest("get a screenshot"):
         machine.wait_for_unit("display-manager.service")


### PR DESCRIPTION
`/var/lib/kolide-k2/...` seems like it is maybe more correct, but `/var/kolide-k2/...` is consistent with the default root directory for launcher on posix systems.

The root directory is still configurable via the module option, but I would like the default to be the consistent choice.