### PR TITLE
Revert "Don't hardcode PATH"

### DIFF
--- a/modules/kolide-launcher/default.nix
+++ b/modules/kolide-launcher/default.nix
@@ -57,6 +57,11 @@ in
       path = with pkgs; [ patchelf ];
 
       serviceConfig = {
+        # The Kolide agent needs to be able to find various executables by looking them up in PATH.
+        # We cannot hardcode a list of packages in systemd.services.kolide-launcher.path because future
+        # autoupdated versions of launcher may need to access new executables not listed in this originally-installed
+        # module. So, until we have a better option, we give the kolide-launcher unit access to the symlinks
+        # in `/run/current-system/sw/bin` and other likely locations that will allow it to find software inside the Nix store.
         Environment = "PATH=/run/wrappers/bin:/bin:/sbin:/nix/var/nix/profiles/default/bin:/run/current-system/sw/bin";
         ExecStart = ''
           ${flake.packages.x86_64-linux.kolide-launcher}/bin/launcher \


### PR DESCRIPTION
Reverts kolide/nix-agent#7

Realized previous approach will not let us access new executables (that may be added in future versions of launcher) from the autoupdated launcher. So, for now, going back to how I had it until I have a better option.