### PR TITLE
Make sure patchelf is in PATH

### DIFF
--- a/modules/kolide-launcher/default.nix
+++ b/modules/kolide-launcher/default.nix
@@ -94,6 +94,7 @@ in
         # autoupdated versions of launcher may need to access new executables not listed in this originally-installed
         # module. So, until we have a better option, we give the kolide-launcher unit access to the symlinks
         # in `/run/current-system/sw/bin` and other likely locations that will allow it to find software inside the Nix store.
+        # The agent also must have explicit access to patchelf, to be able to patch its autoupdates after download.
         Environment = "PATH=/run/wrappers/bin:/bin:/sbin:/nix/var/nix/profiles/default/bin:/run/current-system/sw/bin:${pkgs.patchelf}/bin";
         ExecStart = strings.concatStringsSep " " ([
             "${flake.packages.x86_64-linux.kolide-launcher}/bin/launcher"


### PR DESCRIPTION
`path = with pkgs; [ patchelf ];` is overwritten in the service definition by `Environment = "PATH=...` below, so make sure that patchelf is in the latter definition.