### PR TITLE
Add overlay output, allow overriding NixOS module package, respect Nixpkgs config

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -21,6 +21,6 @@
 
     nixosModules.kolide-launcher = import ./modules/kolide-launcher;
 
-    checks.x86_64-linux.kolide-launcher = import ./tests/kolide-launcher.nix;
+    checks.x86_64-linux.kolide-launcher = import ./tests/kolide-launcher.nix { flake = self; };
   };
 }

--- a/flake.nix
+++ b/flake.nix
@@ -13,7 +13,7 @@
       in
       pkgs.kolide-launcher;
 
-    overlays.x86_64-linux.default = final: prev: {
+    overlays.default = final: prev: {
       kolide-launcher = final.callPackage ./kolide-launcher.nix { };
     };
 

--- a/flake.nix
+++ b/flake.nix
@@ -8,7 +8,7 @@
       let
         pkgs = import nixpkgs {
           system = "x86_64-linux";
-          overlays = [ self.overlays.x86_64-linux.default ];
+          overlays = [ self.overlays.default ];
         };
       in
       pkgs.kolide-launcher;

--- a/flake.nix
+++ b/flake.nix
@@ -5,25 +5,33 @@
 
   outputs = { self, nixpkgs }: {
     packages.x86_64-linux.kolide-launcher =
-      with import nixpkgs { system = "x86_64-linux"; };
-      stdenv.mkDerivation rec {
+      let
+        pkgs = import nixpkgs {
+          system = "x86_64-linux";
+          overlays = [ self.overlays.x86_64-linux.default ];
+        };
+      in
+      pkgs.kolide-launcher;
+
+    overlays.x86_64-linux.default = final: prev: {
+      kolide-launcher = final.stdenv.mkDerivation rec {
         pname = "kolide-launcher";
         version = "1.5.3";
 
-        src = fetchzip {
+        src = final.fetchzip {
           url = "https://dl.kolide.co/kolide/launcher/linux/amd64/launcher-${version}.tar.gz";
           sha256 = "sha256-kLvTMcTKPkvsf/VDNFOQAhGz7nU+kec2koiRofBhB/k=";
           name = "launcher";
         };
 
-        osqSrc = fetchzip {
+        osqSrc = final.fetchzip {
           url = "https://dl.kolide.co/kolide/osqueryd/linux/amd64/osqueryd-5.11.0.tar.gz";
           sha256 = "sha256-gUWow5ZmK7AVBJXkOYQdm1C0gGpr2XExAJgKvSJMnGM=";
           name = "osqueryd";
         };
 
         nativeBuildInputs = [
-          autoPatchelfHook
+          final.autoPatchelfHook
         ];
 
         buildInputs = [];
@@ -34,7 +42,7 @@
           cp $osqSrc/osqueryd $out/bin
         '';
 
-        meta = with lib; {
+        meta = with final.lib; {
           homepage = "https://www.kolide.com";
           description = "Kolide Endpoint Agent";
           platforms = [ "x86_64-linux" ];
@@ -47,6 +55,7 @@
           sourceProvenance = with sourceTypes; [ binaryNativeCode ];
         };
       };
+    };
 
     packages.x86_64-linux.default = self.packages.x86_64-linux.kolide-launcher;
 

--- a/flake.nix
+++ b/flake.nix
@@ -14,53 +14,13 @@
       pkgs.kolide-launcher;
 
     overlays.x86_64-linux.default = final: prev: {
-      kolide-launcher = final.stdenv.mkDerivation rec {
-        pname = "kolide-launcher";
-        version = "1.5.3";
-
-        src = final.fetchzip {
-          url = "https://dl.kolide.co/kolide/launcher/linux/amd64/launcher-${version}.tar.gz";
-          sha256 = "sha256-kLvTMcTKPkvsf/VDNFOQAhGz7nU+kec2koiRofBhB/k=";
-          name = "launcher";
-        };
-
-        osqSrc = final.fetchzip {
-          url = "https://dl.kolide.co/kolide/osqueryd/linux/amd64/osqueryd-5.11.0.tar.gz";
-          sha256 = "sha256-gUWow5ZmK7AVBJXkOYQdm1C0gGpr2XExAJgKvSJMnGM=";
-          name = "osqueryd";
-        };
-
-        nativeBuildInputs = [
-          final.autoPatchelfHook
-        ];
-
-        buildInputs = [];
-
-        installPhase = ''
-          mkdir -p $out/bin
-          cp launcher $out/bin
-          cp $osqSrc/osqueryd $out/bin
-        '';
-
-        meta = with final.lib; {
-          homepage = "https://www.kolide.com";
-          description = "Kolide Endpoint Agent";
-          platforms = [ "x86_64-linux" ];
-          license = {
-            fullName = "The Kolide Enterprise Edition (EE) license";
-            url = "https://github.com/kolide/launcher/blob/main/LICENSE";
-            free = false;
-            redistributable = false;
-          };
-          sourceProvenance = with sourceTypes; [ binaryNativeCode ];
-        };
-      };
+      kolide-launcher = final.callPackage ./kolide-launcher.nix { };
     };
 
     packages.x86_64-linux.default = self.packages.x86_64-linux.kolide-launcher;
 
-    nixosModules.kolide-launcher = import ./modules/kolide-launcher self;
+    nixosModules.kolide-launcher = import ./modules/kolide-launcher;
 
-    checks.x86_64-linux.kolide-launcher = import ./tests/kolide-launcher.nix { flake = self; };
+    checks.x86_64-linux.kolide-launcher = import ./tests/kolide-launcher.nix;
   };
 }

--- a/kolide-launcher.nix
+++ b/kolide-launcher.nix
@@ -1,0 +1,47 @@
+{ autoPatchelfHook
+, fetchzip
+, lib
+, stdenv
+}:
+
+stdenv.mkDerivation rec {
+  pname = "kolide-launcher";
+  version = "1.5.3";
+
+  src = fetchzip {
+    url = "https://dl.kolide.co/kolide/launcher/linux/amd64/launcher-${version}.tar.gz";
+    sha256 = "sha256-kLvTMcTKPkvsf/VDNFOQAhGz7nU+kec2koiRofBhB/k=";
+    name = "launcher";
+  };
+
+  osqSrc = fetchzip {
+    url = "https://dl.kolide.co/kolide/osqueryd/linux/amd64/osqueryd-5.11.0.tar.gz";
+    sha256 = "sha256-gUWow5ZmK7AVBJXkOYQdm1C0gGpr2XExAJgKvSJMnGM=";
+    name = "osqueryd";
+  };
+
+  nativeBuildInputs = [
+    autoPatchelfHook
+  ];
+
+  buildInputs = [];
+
+  installPhase = ''
+    mkdir -p $out/bin
+    cp launcher $out/bin
+    cp $osqSrc/osqueryd $out/bin
+  '';
+
+  meta = with lib; {
+    homepage = "https://www.kolide.com";
+    description = "Kolide Endpoint Agent";
+    platforms = [ "x86_64-linux" ];
+    license = {
+      fullName = "The Kolide Enterprise Edition (EE) license";
+      url = "https://github.com/kolide/launcher/blob/main/LICENSE";
+      free = false;
+      redistributable = false;
+    };
+    sourceProvenance = with sourceTypes; [ binaryNativeCode ];
+  };
+}

--- a/modules/kolide-launcher/default.nix
+++ b/modules/kolide-launcher/default.nix
@@ -1,4 +1,4 @@
-flake: { config, lib, pkgs, ... }:
+{ config, lib, pkgs, ... }:
 
 let
   inherit (lib) types mkDefault mkEnableOption mkOption mkIf optional strings;
@@ -15,7 +15,7 @@ in
 
     package = mkOption {
       type = types.package;
-      default = flake.packages.x86_64-linux.kolide-launcher;
+      default = pkgs.callPackage ../../kolide-launcher.nix { };
       description = lib.mdDoc ''
         The Kolide launcher agent package to use.
       '';

--- a/modules/kolide-launcher/default.nix
+++ b/modules/kolide-launcher/default.nix
@@ -1,9 +1,9 @@
 flake: { config, lib, pkgs, ... }:
 
 let
-  inherit (lib) types mkEnableOption mkOption mkIf optional strings;
-  inherit (flake.packages.x86_64-linux) kolide-launcher;
+  inherit (lib) types mkDefault mkEnableOption mkOption mkIf optional strings;
   cfg = config.services.kolide-launcher;
+  pkg = cfg.package;
 in
 {
   imports = [];
@@ -12,6 +12,14 @@ in
     enable = mkEnableOption ''
       Kolide launcher agent.
     '';
+
+    package = mkOption {
+      type = types.package;
+      default = flake.packages.x86_64-linux.kolide-launcher;
+      description = lib.mdDoc ''
+        The Kolide launcher agent package to use.
+      '';
+    };
 
     kolideHostname = mkOption {
       type = types.str;
@@ -105,10 +113,10 @@ in
         # The agent also must have explicit access to patchelf, to be able to patch its autoupdates after download.
         Environment = "PATH=/run/wrappers/bin:/bin:/sbin:/nix/var/nix/profiles/default/bin:/run/current-system/sw/bin:${pkgs.patchelf}/bin";
         ExecStart = strings.concatStringsSep " " ([
-            "${flake.packages.x86_64-linux.kolide-launcher}/bin/launcher"
+            "${pkg}/bin/launcher"
             "--hostname ${cfg.kolideHostname}"
             "--root_directory ${cfg.rootDirectory}"
-            "--osqueryd_path ${flake.packages.x86_64-linux.kolide-launcher}/bin/osqueryd"
+            "--osqueryd_path ${pkg}/bin/osqueryd"
             "--enroll_secret_path ${cfg.enrollSecretDirectory}/secret"
             "--update_channel ${cfg.updateChannel}"
             "--transport jsonrpc"


### PR DESCRIPTION
This adds an overlay output to the flake, and allows overriding the package used by the NixOS module. The motivation for this was (quoting the first commit):

> Allows re-packaging in your own flake using your Nixpkgs pin's
> configuration, notably `allowUnfree = true`.
> 
> Using the `packages.x86_64-linux.kolide-launcher` derivation directly
> doesn't respect your Nixpkgs config because it relies on vanilla Nixpkgs
> from the flake input.

Commits are atomic; I recommend reviewing them individually.

Thanks for supporting Nix/NixOS!