### PR TITLE
[Release] Bump launcher to v1.9.6

### DIFF
--- a/kolide-launcher.nix
+++ b/kolide-launcher.nix
@@ -10,7 +10,7 @@ stdenv.mkDerivation rec {
 
   src = fetchzip {
     url = "https://dl.kolide.co/kolide/launcher/linux/amd64/launcher-${version}.tar.gz";
-    sha256 = "";
+    sha256 = "sha256-AE0TYeoKBCOz8Sq95fk2AdvqW6kRknyLwUp587p3gVo=";
     name = "launcher";
   };
 

--- a/kolide-launcher.nix
+++ b/kolide-launcher.nix
@@ -6,11 +6,11 @@
 
 stdenv.mkDerivation rec {
   pname = "kolide-launcher";
-  version = "1.9.4";
+  version = "1.9.6";
 
   src = fetchzip {
     url = "https://dl.kolide.co/kolide/launcher/linux/amd64/launcher-${version}.tar.gz";
-    sha256 = "sha256-5zDu8WQyM4SM8ByvTYU1QR6zdxU/RJJWHCoVyceuTTA=";
+    sha256 = "";
     name = "launcher";
   };
 


### PR DESCRIPTION
https://github.com/kolide/launcher/releases/tag/v1.9.6