### PR TITLE
Add support for forwarding `osquery_flag` arguments to the kolide launcher

### DIFF
--- a/modules/kolide-launcher/default.nix
+++ b/modules/kolide-launcher/default.nix
@@ -87,11 +87,11 @@ in
       '';
     };
 
-    osQueryFlags = mkOption {
+    osqueryFlags = mkOption {
       type = types.listOf types.str;
       default = [];
       description = ''
-        OsQuery flags to pass via the agent.
+        Flags to pass to osquery (possibly overriding Launcher defaults).
       '';
     };
 
@@ -135,7 +135,7 @@ in
           ++ optional cfg.insecureTransport "--insecure_transport"
           ++ optional cfg.insecureTLS "--insecure"
           ++ optional (!builtins.isNull cfg.localdevPath) "--localdev_path ${cfg.localdevPath}"
-          ++ map (x: "--osquery_flag ${x}") cfg.osQueryFlags
+          ++ map (x: "--osquery_flag ${x}") cfg.osqueryFlags
         );
         Restart = "on-failure";
         RestartSec = 3;

--- a/modules/kolide-launcher/default.nix
+++ b/modules/kolide-launcher/default.nix
@@ -91,7 +91,7 @@ in
       type = types.listOf types.str;
       default = [];
       description = ''
-        OsQuery flagsto pass via the agent.
+        OsQuery flags to pass via the agent.
       '';
     };
 

--- a/modules/kolide-launcher/default.nix
+++ b/modules/kolide-launcher/default.nix
@@ -87,6 +87,14 @@ in
       '';
     };
 
+    osQueryFlags = mkOption {
+      type = types.listOf types.str;
+      default = [];
+      description = ''
+        OsQuery flagsto pass via the agent.
+      '';
+    };
+
     localdevPath = mkOption {
       type = types.nullOr types.path;
       default = null;
@@ -124,10 +132,11 @@ in
             "--autoupdate_interval ${cfg.autoupdateInterval}"
             "--autoupdater_initial_delay ${cfg.autoupdaterInitialDelay}"
           ]
-            ++ optional cfg.insecureTransport "--insecure_transport"
-            ++ optional cfg.insecureTLS "--insecure"
-            ++ optional (!builtins.isNull cfg.localdevPath) "--localdev_path ${cfg.localdevPath}"
-          );
+          ++ optional cfg.insecureTransport "--insecure_transport"
+          ++ optional cfg.insecureTLS "--insecure"
+          ++ optional (!builtins.isNull cfg.localdevPath) "--localdev_path ${cfg.localdevPath}"
+          ++ map (x: "--osquery_flag ${x}") cfg.osQueryFlags
+        );
         Restart = "on-failure";
         RestartSec = 3;
       };


### PR DESCRIPTION
This is required by some vendors to provide host identifiers that are hardcoded in the configuration. Providing this makes it much simpler to configure.