### PR TITLE
[Release] Bump launcher to v1.17.0 and osquery to v5.16.0

### DIFF
--- a/kolide-launcher.nix
+++ b/kolide-launcher.nix
@@ -10,7 +10,7 @@ stdenv.mkDerivation rec {
 
   src = fetchzip {
     url = "https://dl.kolide.co/kolide/launcher/linux/amd64/launcher-${version}.tar.gz";
-    sha256 = "sha256-shJMPtz3txgRRw0sc9bNgYUy9cw9TkVGYI/nAO6TbDg=";
+    sha256 = "sha256-SjUcNX1kQhI7ovhf6RhiAib+kR2R4QiHft7LSljU21k=";
     name = "launcher";
   };
 

--- a/kolide-launcher.nix
+++ b/kolide-launcher.nix
@@ -6,7 +6,7 @@
 
 stdenv.mkDerivation rec {
   pname = "kolide-launcher";
-  version = "1.12.3";
+  version = "1.17.0";
 
   src = fetchzip {
     url = "https://dl.kolide.co/kolide/launcher/linux/amd64/launcher-${version}.tar.gz";
@@ -15,7 +15,7 @@ stdenv.mkDerivation rec {
   };
 
   osqSrc = fetchzip {
-    url = "https://dl.kolide.co/kolide/osqueryd/linux/amd64/osqueryd-5.14.1.tar.gz";
+    url = "https://dl.kolide.co/kolide/osqueryd/linux/amd64/osqueryd-5.16.0.tar.gz";
     sha256 = "sha256-rcmoXshD9pwaTN2dgJm9ZmuCuNQkPgLxghtMGYfhfYE=";
     name = "osqueryd";
   };

--- a/kolide-launcher.nix
+++ b/kolide-launcher.nix
@@ -16,7 +16,7 @@ stdenv.mkDerivation rec {
 
   osqSrc = fetchzip {
     url = "https://dl.kolide.co/kolide/osqueryd/linux/amd64/osqueryd-5.16.0.tar.gz";
-    sha256 = "sha256-rcmoXshD9pwaTN2dgJm9ZmuCuNQkPgLxghtMGYfhfYE=";
+    sha256 = "sha256-SU8zTTRF64+lv8ADeW/ydPRMDbRKvwCM03rQ+RcbWic=";
     name = "osqueryd";
   };
 


### PR DESCRIPTION
https://github.com/kolide/launcher/releases/tag/v1.17.0

https://github.com/osquery/osquery/releases/tag/5.16.0