### PR TITLE
Remove mddoc

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+.direnv
+.envrc*

--- a/modules/kolide-launcher/default.nix
+++ b/modules/kolide-launcher/default.nix
@@ -16,7 +16,7 @@ in
     package = mkOption {
       type = types.package;
       default = pkgs.callPackage ../../kolide-launcher.nix { };
-      description = lib.mdDoc ''
+      description = ''
         The Kolide launcher agent package to use.
       '';
     };


### PR DESCRIPTION
`lib.mdDoc` has been removed in https://github.com/NixOS/nixpkgs/pull/303841.