### PR TITLE
[Release] Bump launcher to launcher v1.23.1 and osqueryd to 5.18.1

### DIFF
--- a/kolide-launcher.nix
+++ b/kolide-launcher.nix
@@ -10,7 +10,7 @@ stdenv.mkDerivation rec {
 
   src = fetchzip {
     url = "https://dl.kolide.co/kolide/launcher/linux/amd64/launcher-${version}.tar.gz";
-    sha256 = "sha256-cOppcheWqwHUnOj4ru7fvSyUkNdXLz8w4h+KG1BtLuk=";
+    sha256 = "sha256-nbfNnqV+Q7Mc54CAf7LxKUizByamfVqekPm2MjP53p4=";
     name = "launcher";
   };
 

--- a/kolide-launcher.nix
+++ b/kolide-launcher.nix
@@ -6,7 +6,7 @@
 
 stdenv.mkDerivation rec {
   pname = "kolide-launcher";
-  version = "1.17.0";
+  version = "1.23.1";
 
   src = fetchzip {
     url = "https://dl.kolide.co/kolide/launcher/linux/amd64/launcher-${version}.tar.gz";
@@ -15,7 +15,7 @@ stdenv.mkDerivation rec {
   };
 
   osqSrc = fetchzip {
-    url = "https://dl.kolide.co/kolide/osqueryd/linux/amd64/osqueryd-5.16.0.tar.gz";
+    url = "https://dl.kolide.co/kolide/osqueryd/linux/amd64/osqueryd-5.18.1.tar.gz";
     sha256 = "sha256-SU8zTTRF64+lv8ADeW/ydPRMDbRKvwCM03rQ+RcbWic=";
     name = "osqueryd";
   };

--- a/kolide-launcher.nix
+++ b/kolide-launcher.nix
@@ -16,7 +16,7 @@ stdenv.mkDerivation rec {
 
   osqSrc = fetchzip {
     url = "https://dl.kolide.co/kolide/osqueryd/linux/amd64/osqueryd-5.18.1.tar.gz";
-    sha256 = "sha256-SU8zTTRF64+lv8ADeW/ydPRMDbRKvwCM03rQ+RcbWic=";
+    sha256 = "sha256-kozONOHLF+Z36ZSFI4IsRqpYi5A+TDS6qjBdewof83I=";
     name = "osqueryd";
   };
 


### PR DESCRIPTION
https://github.com/kolide/launcher/releases/tag/v1.23.1

https://github.com/osquery/osquery/releases/tag/5.18.1