### PR TITLE
Update calculate-hash job

### DIFF
--- a/.github/workflows/calculate-hash.yml
+++ b/.github/workflows/calculate-hash.yml
@@ -35,4 +35,4 @@ jobs:
     - name: calculate SRI hash for fetchzip
       run: |
         downloadUrl="https://dl.kolide.co/kolide/${{ github.event.inputs.binary }}/linux/${{ github.event.inputs.arch }}/${{ github.event.inputs.binary }}-${{ github.event.inputs.version }}.tar.gz"
-        nix-build -E "with import <nixpkgs> {}; fetchzip {url = \"$downloadUrl\"; sha256 = lib.fakeSha256; }"
+        nix-build -E "with import <nixpkgs> {}; fetchzip { url = \"$downloadUrl\"; sha256 = lib.fakeSha256; }"

--- a/.github/workflows/calculate-hash.yml
+++ b/.github/workflows/calculate-hash.yml
@@ -34,6 +34,5 @@ jobs:
 
     - name: calculate SRI hash for fetchzip
       run: |
-        nix-hash --type sha256 --to-sri $(nix-prefetch-url --type sha256 --unpack https://dl.kolide.co/kolide/${{ github.event.inputs.binary }}/linux/${{ github.event.inputs.arch }}/${{ github.event.inputs.binary }}-${{ github.event.inputs.version }}.tar.gz)
-        cat /nix/store/*-launcher-* | openssl dgst -sha384 -binary | openssl base64 -A
-        cat /nix/store/*-launcher-* | openssl dgst -sha256 -binary | openssl base64 -A
+        downloadUrl="https://dl.kolide.co/kolide/${{ github.event.inputs.binary }}/linux/${{ github.event.inputs.arch }}/${{ github.event.inputs.binary }}-${{ github.event.inputs.version }}.tar.gz"
+        nix-build -E "with import <nixpkgs> {}; fetchzip {url = \"$downloadUrl\"; sha256 = lib.fakeSha256; }"

--- a/.github/workflows/calculate-hash.yml
+++ b/.github/workflows/calculate-hash.yml
@@ -37,3 +37,5 @@ jobs:
         nix-prefetch-url --type sha256 --unpack --print-path https://dl.kolide.co/kolide/${{ github.event.inputs.binary }}/linux/${{ github.event.inputs.arch }}/${{ github.event.inputs.binary }}-${{ github.event.inputs.version }}.tar.gz
         nix-prefetch-url --type sha256 --print-path https://dl.kolide.co/kolide/${{ github.event.inputs.binary }}/linux/${{ github.event.inputs.arch }}/${{ github.event.inputs.binary }}-${{ github.event.inputs.version }}.tar.gz
         nix-hash --type sha256 --to-sri $(nix-prefetch-url --type sha256 --unpack https://dl.kolide.co/kolide/${{ github.event.inputs.binary }}/linux/${{ github.event.inputs.arch }}/${{ github.event.inputs.binary }}-${{ github.event.inputs.version }}.tar.gz)
+        nix-hash --type sha256 --to-sri $(nix-prefetch-url --type sha256 https://dl.kolide.co/kolide/${{ github.event.inputs.binary }}/linux/${{ github.event.inputs.arch }}/${{ github.event.inputs.binary }}-${{ github.event.inputs.version }}.tar.gz)
+

--- a/.github/workflows/calculate-hash.yml
+++ b/.github/workflows/calculate-hash.yml
@@ -38,4 +38,5 @@ jobs:
         nix-prefetch-url --type sha256 --print-path https://dl.kolide.co/kolide/${{ github.event.inputs.binary }}/linux/${{ github.event.inputs.arch }}/${{ github.event.inputs.binary }}-${{ github.event.inputs.version }}.tar.gz
         nix-hash --type sha256 --to-sri $(nix-prefetch-url --type sha256 --unpack https://dl.kolide.co/kolide/${{ github.event.inputs.binary }}/linux/${{ github.event.inputs.arch }}/${{ github.event.inputs.binary }}-${{ github.event.inputs.version }}.tar.gz)
         nix-hash --type sha256 --to-sri $(nix-prefetch-url --type sha256 https://dl.kolide.co/kolide/${{ github.event.inputs.binary }}/linux/${{ github.event.inputs.arch }}/${{ github.event.inputs.binary }}-${{ github.event.inputs.version }}.tar.gz)
+        ls -al /nix/store/*-launcher-*
 

--- a/.github/workflows/calculate-hash.yml
+++ b/.github/workflows/calculate-hash.yml
@@ -34,4 +34,5 @@ jobs:
 
     - name: calculate SRI hash for fetchzip
       run: |
+        nix hash to-sri sha256:$(nix-prefetch-url https://dl.kolide.co/kolide/${{ github.event.inputs.binary }}/linux/${{ github.event.inputs.arch }}/${{ github.event.inputs.binary }}-${{ github.event.inputs.version }}.tar.gz --type sha256 --unpack)
         nix-hash --type sha256 --to-sri $(nix-prefetch-url https://dl.kolide.co/kolide/${{ github.event.inputs.binary }}/linux/${{ github.event.inputs.arch }}/${{ github.event.inputs.binary }}-${{ github.event.inputs.version }}.tar.gz --type sha256 --unpack)

--- a/.github/workflows/calculate-hash.yml
+++ b/.github/workflows/calculate-hash.yml
@@ -28,9 +28,9 @@ jobs:
 
     steps:
 
-    - uses: cachix/install-nix-action@v22
+    - uses: cachix/install-nix-action@v31
       with:
-        nix_path: nixpkgs=channel:nixos-23.11
+        nix_path: nixpkgs=channel:nixos-24.11
 
     - name: calculate SRI hash for fetchzip
       run: |

--- a/.github/workflows/calculate-hash.yml
+++ b/.github/workflows/calculate-hash.yml
@@ -35,4 +35,5 @@ jobs:
     - name: calculate SRI hash for fetchzip
       run: |
         nix-prefetch-url --type sha256 --unpack --print-path https://dl.kolide.co/kolide/${{ github.event.inputs.binary }}/linux/${{ github.event.inputs.arch }}/${{ github.event.inputs.binary }}-${{ github.event.inputs.version }}.tar.gz
+        nix-prefetch-url --type sha256 --print-path https://dl.kolide.co/kolide/${{ github.event.inputs.binary }}/linux/${{ github.event.inputs.arch }}/${{ github.event.inputs.binary }}-${{ github.event.inputs.version }}.tar.gz
         nix-hash --type sha256 --to-sri $(nix-prefetch-url --type sha256 --unpack https://dl.kolide.co/kolide/${{ github.event.inputs.binary }}/linux/${{ github.event.inputs.arch }}/${{ github.event.inputs.binary }}-${{ github.event.inputs.version }}.tar.gz)

--- a/.github/workflows/calculate-hash.yml
+++ b/.github/workflows/calculate-hash.yml
@@ -34,9 +34,6 @@ jobs:
 
     - name: calculate SRI hash for fetchzip
       run: |
-        nix-prefetch-url --type sha256 --unpack --print-path https://dl.kolide.co/kolide/${{ github.event.inputs.binary }}/linux/${{ github.event.inputs.arch }}/${{ github.event.inputs.binary }}-${{ github.event.inputs.version }}.tar.gz
-        nix-prefetch-url --type sha256 --print-path https://dl.kolide.co/kolide/${{ github.event.inputs.binary }}/linux/${{ github.event.inputs.arch }}/${{ github.event.inputs.binary }}-${{ github.event.inputs.version }}.tar.gz
         nix-hash --type sha256 --to-sri $(nix-prefetch-url --type sha256 --unpack https://dl.kolide.co/kolide/${{ github.event.inputs.binary }}/linux/${{ github.event.inputs.arch }}/${{ github.event.inputs.binary }}-${{ github.event.inputs.version }}.tar.gz)
-        nix-hash --type sha256 --to-sri $(nix-prefetch-url --type sha256 https://dl.kolide.co/kolide/${{ github.event.inputs.binary }}/linux/${{ github.event.inputs.arch }}/${{ github.event.inputs.binary }}-${{ github.event.inputs.version }}.tar.gz)
-        ls -al /nix/store/*-launcher-*
-
+        cat /nix/store/*-launcher-* | openssl dgst -sha384 -binary | openssl base64 -A
+        cat /nix/store/*-launcher-* | openssl dgst -sha256 -binary | openssl base64 -A

--- a/.github/workflows/calculate-hash.yml
+++ b/.github/workflows/calculate-hash.yml
@@ -23,7 +23,7 @@ on:
           - arm64
 
 jobs:
-  validate:
+  calculate-hash:
     runs-on: ubuntu-latest
 
     steps:
@@ -34,4 +34,4 @@ jobs:
 
     - name: calculate SRI hash for fetchzip
       run: |
-        nix-hash --type sha256 --to-sri $(nix-prefetch-url --unpack https://dl.kolide.co/kolide/${{ github.event.inputs.binary }}/linux/${{ github.event.inputs.arch }}/${{ github.event.inputs.binary }}-${{ github.event.inputs.version }}.tar.gz)
+        nix-hash --type sha256 --to-sri $(nix-prefetch-url --type sha256 --unpack https://dl.kolide.co/kolide/${{ github.event.inputs.binary }}/linux/${{ github.event.inputs.arch }}/${{ github.event.inputs.binary }}-${{ github.event.inputs.version }}.tar.gz)

--- a/.github/workflows/calculate-hash.yml
+++ b/.github/workflows/calculate-hash.yml
@@ -34,4 +34,4 @@ jobs:
 
     - name: calculate SRI hash for fetchzip
       run: |
-        nix-hash --type sha256 --to-sri $(nix-prefetch-url --type sha256 --unpack https://dl.kolide.co/kolide/${{ github.event.inputs.binary }}/linux/${{ github.event.inputs.arch }}/${{ github.event.inputs.binary }}-${{ github.event.inputs.version }}.tar.gz)
+        nix-hash --type sha256 --to-sri $(nix-prefetch-url https://dl.kolide.co/kolide/${{ github.event.inputs.binary }}/linux/${{ github.event.inputs.arch }}/${{ github.event.inputs.binary }}-${{ github.event.inputs.version }}.tar.gz --type sha256 --unpack)

--- a/.github/workflows/calculate-hash.yml
+++ b/.github/workflows/calculate-hash.yml
@@ -34,5 +34,5 @@ jobs:
 
     - name: calculate SRI hash for fetchzip
       run: |
-        nix hash to-sri sha256:$(nix-prefetch-url https://dl.kolide.co/kolide/${{ github.event.inputs.binary }}/linux/${{ github.event.inputs.arch }}/${{ github.event.inputs.binary }}-${{ github.event.inputs.version }}.tar.gz --type sha256 --unpack)
-        nix-hash --type sha256 --to-sri $(nix-prefetch-url https://dl.kolide.co/kolide/${{ github.event.inputs.binary }}/linux/${{ github.event.inputs.arch }}/${{ github.event.inputs.binary }}-${{ github.event.inputs.version }}.tar.gz --type sha256 --unpack)
+        nix-prefetch-url --type sha256 --unpack --print-path https://dl.kolide.co/kolide/${{ github.event.inputs.binary }}/linux/${{ github.event.inputs.arch }}/${{ github.event.inputs.binary }}-${{ github.event.inputs.version }}.tar.gz
+        nix-hash --type sha256 --to-sri $(nix-prefetch-url --type sha256 --unpack https://dl.kolide.co/kolide/${{ github.event.inputs.binary }}/linux/${{ github.event.inputs.arch }}/${{ github.event.inputs.binary }}-${{ github.event.inputs.version }}.tar.gz)


### PR DESCRIPTION
Fixes for https://github.com/kolide/nix-agent/pull/40

We can't actually use `nix-prefetch-url` -- as explained [here](https://github.com/NixOS/nixpkgs/issues/111508#issuecomment-770832252), `fetchzip` performs additional normalization to the files, so the hash calculated using `nix-prefetch-url` was never correct for us.

So, we go back to doing it the approved way: use a blank hash and try to build a derivation using `fetchzip`, allowing it to fail and tell us the correct hash.

Job calculating hash correctly: https://github.com/kolide/nix-agent/actions/runs/16754523440