### PR TITLE
ci/flake:  nixpkgs to 26.05, lock down/update 3rd party actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,7 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+

--- a/.github/workflows/agent-release.yml
+++ b/.github/workflows/agent-release.yml
@@ -56,7 +56,7 @@ jobs:
       - name: Install Nix
         uses: cachix/install-nix-action@a49548c11d9846ad46ecc0115273879b045f001c # v37.10.7
         with:
-          nix_path: nixpkgs=channel:nixos-24.11
+          nix_path: nixpkgs=channel:nixos-26.05
 
       - name: Calculate SHA256 hashes
         id: calculate-hashes

--- a/.github/workflows/agent-release.yml
+++ b/.github/workflows/agent-release.yml
@@ -54,7 +54,7 @@ jobs:
       pull-requests: write
     steps:
       - name: Install Nix
-        uses: cachix/install-nix-action@v31
+        uses: cachix/install-nix-action@a49548c11d9846ad46ecc0115273879b045f001c # v37.10.7
         with:
           nix_path: nixpkgs=channel:nixos-24.11
 

--- a/.github/workflows/calculate-hash.yml
+++ b/.github/workflows/calculate-hash.yml
@@ -28,7 +28,7 @@ jobs:
 
     steps:
 
-    - uses: cachix/install-nix-action@v31
+    - uses: cachix/install-nix-action@a49548c11d9846ad46ecc0115273879b045f001c # v37.10.7
       with:
         nix_path: nixpkgs=channel:nixos-24.11
 

--- a/.github/workflows/calculate-hash.yml
+++ b/.github/workflows/calculate-hash.yml
@@ -30,7 +30,7 @@ jobs:
 
     - uses: cachix/install-nix-action@a49548c11d9846ad46ecc0115273879b045f001c # v37.10.7
       with:
-        nix_path: nixpkgs=channel:nixos-24.11
+        nix_path: nixpkgs=channel:nixos-26.05
 
     - name: calculate SRI hash for fetchzip
       run: |

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -35,7 +35,7 @@ jobs:
       if: ${{ contains(matrix.os, 'ubuntu-latest') }}
       with:
         extra_nix_config: "system-features = nixos-test benchmark big-parallel kvm"
-        nix_path: nixpkgs=channel:nixos-24.11
+        nix_path: nixpkgs=channel:nixos-26.05
 
     - uses: cachix/install-nix-action@a49548c11d9846ad46ecc0115273879b045f001c # v37.10.7
       if: ${{ contains(matrix.os, 'ubuntu-24.04-arm') }}
@@ -43,7 +43,7 @@ jobs:
         extra_nix_config: |
           system-features = nixos-test benchmark big-parallel kvm
           system = aarch64-linux
-        nix_path: nixpkgs=channel:nixos-24.11
+        nix_path: nixpkgs=channel:nixos-26.05
 
     - name: build
       run: NIXPKGS_ALLOW_UNFREE=1 nix build --impure

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -31,13 +31,13 @@ jobs:
         sudo apt-get install -y qemu-system-aarch64 binfmt-support qemu-user-static
         sudo usermod -a -G kvm $USER
 
-    - uses: cachix/install-nix-action@v31
+    - uses: cachix/install-nix-action@a49548c11d9846ad46ecc0115273879b045f001c # v37.10.7
       if: ${{ contains(matrix.os, 'ubuntu-latest') }}
       with:
         extra_nix_config: "system-features = nixos-test benchmark big-parallel kvm"
         nix_path: nixpkgs=channel:nixos-24.11
 
-    - uses: cachix/install-nix-action@v31
+    - uses: cachix/install-nix-action@a49548c11d9846ad46ecc0115273879b045f001c # v37.10.7
       if: ${{ contains(matrix.os, 'ubuntu-24.04-arm') }}
       with:
         extra_nix_config: |

--- a/flake.lock
+++ b/flake.lock
@@ -18,16 +18,16 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1706098335,
-        "narHash": "sha256-r3dWjT8P9/Ah5m5ul4WqIWD8muj5F+/gbCdjiNVBKmU=",
+        "lastModified": 1784011430,
+        "narHash": "sha256-lDebytrYdd47IBLwvNOD+6AGeoqZ78CIKlp70hzW280=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "a77ab169a83a4175169d78684ddd2e54486ac651",
+        "rev": "8eeec934ae0dbeca3d7868c059568a65c08b2fc3",
         "type": "github"
       },
       "original": {
         "owner": "nixos",
-        "ref": "nixos-23.11",
+        "ref": "nixos-26.05",
         "repo": "nixpkgs",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -2,7 +2,7 @@
   description = "Kolide launcher";
 
   inputs = {
-    nixpkgs.url = "github:nixos/nixpkgs/nixos-23.11";
+    nixpkgs.url = "github:nixos/nixpkgs/nixos-26.05";
 
     flake-compat = {
       url = "github:NixOS/flake-compat";


### PR DESCRIPTION
[KOL-786](https://1password.atlassian.net/browse/KOL-786)

GitHub hardening docs [recommend pinning third party actions](https://docs.github.com/en/actions/reference/security/secure-use#using-third-party-actions). And our nixpkgs here were _very_ EOL; I do not thing it is on purpose (per last update https://github.com/kolide/nix-agent/pull/17).

Nothing stuck out to me unused/for deletion. We could manually set up nix, but this action is handy.

Changes:
  - Lock down and bump nix-action v31 -> v37
  - Configure dependabot for GitHub actions
  - flake nixpkgs 23.05 -> 26.05 
  - CI nixpkgs 23.11 -> 26.05

---

Testing locally on x86_64 LGTM:

    $ NIXPKGS_ALLOW_UNFREE=1 nix run ".#" --impure
    error: unable to execute '/nix/store/j5l7c01dz8hc4r68vnrpjkkjmcws78m5-kolide-launcher-2.4.0/bin/kolide-launcher': No such file or directory
    $ cp /nix/store/j5l7c01dz8hc4r68vnrpjkkjmcws78m5-kolide-launcher-2.4.0/bin/launcher .
    $ patchelf launcher
    $ ./launcher
    {"time":"2026-07-14T15:40:50.460858936Z","level":"INFO","msg":"launcher starting up","version":"2.4.0","revision":"c9548809578c64d965d94a1adbe0f4122bc35c2a"}
    {"time":"2026-07-14T15:40:50.461023712Z","level":"INFO","msg":"got new version of launcher to run","old_version":"2.4.0","new_binary_version":"","new_binary_path":"/home/billy/work/launcher/build/launcher"}
    {"time":"2026-07-14T15:40:50.461042427Z","level":"INFO","msg":"found newer version of launcher to run","new_binary":"/home/billy/work/launcher/build/launcher"}
    {"time":"2026-07-14T15:40:50.471359943Z","level":"INFO","msg":"launcher starting up","version":"unknown","revision":"unknown"}
    [...]